### PR TITLE
Fix random number generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
 sudo: false
 node_js:
-  - "io.js"
-  - "node"
   - "lts/*"

--- a/browser.js
+++ b/browser.js
@@ -405,10 +405,8 @@ SRP6JavascriptClientSession.prototype.random16byteHex = function() {
 SRP6JavascriptClientSession.prototype.randomA = function(N) {
     "use strict";
 
-    //console.log("N:"+N);
-
     // our ideal number of random  bits to use for `a` as long as its bigger than 256 bits
-    var hexLength = this.toHex(N).length;
+    var hexLength = this.toHex(N()).length;
 
     var ZERO = this.BigInteger("0", 10);
     var ONE = this.BigInteger("1", 10);
@@ -446,7 +444,7 @@ SRP6JavascriptClientSession.prototype.randomA = function(N) {
         // this protected against a buggy browser random number generated generating a constant value
         // we mod(N) to wrap to the range [0,N) then loop if we get 0 to give [1,N)
         // mod(N) is broken due to buggy library code so we workaround with modPow(1,N)
-        r = (oneTimeBi.add(rBi)).modPow(ONE, N);
+        r = (oneTimeBi.add(rBi)).modPow(ONE, N());
     }
 
     //console.log("r:"+r);


### PR DESCRIPTION
The current version of thinbus-srp generates small random values for the challenge computation (randomA) because it accesses N like a value rather than a function. Eg. var hexLength = this.toHex(N).length; uses the length of the textual function representation rather than N's byte length.